### PR TITLE
Allow input variables in output equation

### DIFF
--- a/simupy/systems/symbolic.py
+++ b/simupy/systems/symbolic.py
@@ -148,7 +148,7 @@ class DynamicalSystem(DynamicalSystemBase):
                    )
 
             if self.dim_state:
-                assert find_dynamicsymbols(output_equation) <= set(self.state)
+                assert find_dynamicsymbols(output_equation) <= set(self.state) or set(self.input)
             else:
                 assert find_dynamicsymbols(output_equation) <= set(self.input)
 


### PR DESCRIPTION
Hi,

I'am currently working on a nonlinear control toolbox, which is built on top of your simupy module (more info [here](https://nlcontrol.readthedocs.io/en/latest/)). Thank you for the nice module. It helped me a lot to progress efficiently. 

In control loops, the controller and the system can be built up by parallel en series configurations of systems, which I implemented in the `nlcontrol` toolbox. In this configuration it can occure that there are input variables in the output equation. Therefore, I suggest the following small adaptation.

Thank you for considering my PR.

Kind regards
Jasper